### PR TITLE
[fix] fix args in compute_reinforce_rej_outcome_advantage

### DIFF
--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -237,7 +237,8 @@ def compute_advantage(data: DataProto, adv_estimator, gamma=1.0, lam=1.0, num_re
     elif adv_estimator == AdvantageEstimator.REINFORCE_REJ:
         advantages, returns = core_algos.compute_reinforce_rej_outcome_advantage(
             token_level_rewards=data.batch['token_level_rewards'],
-            response_mask=data.batch['response_mask'])
+            response_mask=data.batch['response_mask'],
+            index=data.non_tensor_batch['uid'])
         data.batch['advantages'] = advantages
         data.batch['returns'] = returns
     else:


### PR DESCRIPTION
```
  File "/nfs/ofs-llab-volume/users/fengyu/new_verl/verl/verl/trainer/main_ppo.py", line 194, in run
    trainer.fit()
  File "/nfs/ofs-llab-volume/users/fengyu/new_verl/verl/verl/trainer/ppo/ray_trainer.py", line 954, in fit
    batch = compute_advantage(batch,
  File "/nfs/ofs-llab-volume/users/fengyu/new_verl/verl/verl/trainer/ppo/ray_trainer.py", line 238, in compute_advantage
    advantages, returns = core_algos.compute_reinforce_rej_outcome_advantage(
TypeError: compute_reinforce_rej_outcome_advantage() missing 1 required positional argument: 'index'
```
fix bug miss param in compute_reinforce_rej_outcome_advantage